### PR TITLE
added `pass_filenames: false` to the .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,5 +2,6 @@
   name: Django UrlConf Checks
   description: a pre-commit for type checking the urls and associated views
   entry: urlconfchecks
+  pass_filenames: false
   language: python
   types: [ python ]


### PR DESCRIPTION
The default is true, which causes problems because `urlconfchecks` doesn't work with files individually.