### PR TITLE
 ignored django admin app to check for type safety

### DIFF
--- a/django_urlconfchecks/check.py
+++ b/django_urlconfchecks/check.py
@@ -32,6 +32,8 @@ def check_url_signatures(app_configs, **kwargs) -> t.List[t.Union[checks.Error, 
 
 def get_all_routes(resolver: URLResolver) -> t.Iterable[URLPattern]:
     """Recursively get all routes from the resolver."""
+    if resolver.app_name == 'admin':
+        return []
     for pattern in resolver.url_patterns:
         if isinstance(pattern, URLResolver):
             yield from get_all_routes(pattern)

--- a/tests/dummy_project/settings.py
+++ b/tests/dummy_project/settings.py
@@ -8,6 +8,7 @@ DATABASES = {
 }
 ROOT_URLCONF = ("tests.dummy_project.urls.correct_urls",)
 INSTALLED_APPS = [
+    "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.sites",

--- a/tests/dummy_project/urls/admin_urls.py
+++ b/tests/dummy_project/urls/admin_urls.py
@@ -1,8 +1,6 @@
 """admin urls for test."""
 
-from django.urls import path
-
 from django.contrib import admin
-
+from django.urls import path
 
 urlpatterns = [path('admin/', admin.site.urls)]

--- a/tests/dummy_project/urls/admin_urls.py
+++ b/tests/dummy_project/urls/admin_urls.py
@@ -1,0 +1,8 @@
+"""admin urls for test."""
+
+from django.urls import path
+
+from django.contrib import admin
+
+
+urlpatterns = [path('admin/', admin.site.urls)]

--- a/tests/test_url_checker.py
+++ b/tests/test_url_checker.py
@@ -69,3 +69,15 @@ def test_child_urls_checked():
         resolver = get_resolver()
         routes = get_all_routes(resolver)
         assert len(list(routes)) == 3
+
+
+def test_admin_urls_checked():
+    """Test that admin urls are ignored.
+
+    Returns:
+        None
+    """
+    with override_settings(ROOT_URLCONF='tests.dummy_project.urls.admin_urls'):
+        resolver = get_resolver()
+        routes = get_all_routes(resolver)
+        assert len(list(routes)) == 0


### PR DESCRIPTION
Hi, can you review the code please if it is safe to push or if I have used any bad practices in the code? I have ignored that the `admin` app returned an empty `list` instead so it will not show a warning for that.