### PR TITLE
Support subclasses of builtin converters

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,9 @@ max-line-length = 120
 max-complexity = 18
 ignore = E203, E266, W503, D107
 docstring-convention = google
-per-file-ignores = __init__.py:F401
+per-file-ignores =
+    __init__.py:F401
+    tests/*:D101,D102,D103
 exclude = .git,
     __pycache__,
     setup.py,

--- a/tests/dummy_project/urls/converter_urls.py
+++ b/tests/dummy_project/urls/converter_urls.py
@@ -1,0 +1,53 @@
+"""URLs using custom converters and subclassed converters, with errors."""
+from django.urls import path, register_converter
+from django.urls.converters import IntConverter
+
+from tests.dummy_project import views
+
+
+class YearConverter:
+    # Converter with type hint on to_python, should be handled automatically.
+    regex = "[0-9]{4}"
+
+    def to_python(self, value: str) -> int:
+        return int(value)
+
+    def to_url(self, value: int):
+        return f"{value:04}"
+
+
+class YearConverterNoTypeHint:
+    # Converter with no type hint, should raise warning
+    regex = "[0-9]{4}"
+
+    def to_python(self, value: str):
+        return int(value)
+
+    def to_url(self, value: int):
+        return f"{value:04}"
+
+
+class YearConverterViaSubclass(IntConverter):
+    # Subclass converter, no to_python method,
+    # so we should default to the type inferred for base class
+    regex = "[0-9]{4}"
+
+
+class YearConverterAsFloat(IntConverter):
+    # Subclass - for this case we should infer from the sig on to_python
+    # method, not the base class (this float type will cause a type error)
+    def to_python(self, value: str) -> float:
+        return float(super().to_python(value))
+
+
+register_converter(YearConverter, "yyyy")
+register_converter(YearConverterNoTypeHint, "yyyy_notype")
+register_converter(YearConverterViaSubclass, "yyyy_subclass")
+register_converter(YearConverterAsFloat, "yyyy_float")
+
+urlpatterns = [
+    path('articles_yyyy/<yyyy:year>/', views.year_archive),
+    path('articles_yyyy_notype/<yyyy_notype:year>/', views.year_archive),
+    path('articles_yyyy_subclass/<yyyy_subclass:year>/', views.year_archive),
+    path('articles_yyyy_float/<yyyy_float:year>/', views.year_archive),
+]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -49,9 +49,15 @@ def error_eql(error: checks.Error, expected_error: checks.Error) -> bool:
     Returns:
         True if the Error objects are equal, False otherwise.
     """
+    if isinstance(error.obj, URLPattern) and isinstance(expected_error.obj, URLPattern):
+        obj_equal = url_pattern_eql(error.obj, expected_error.obj)
+    elif isinstance(error.obj, type) and isinstance(expected_error.obj, type):
+        obj_equal = error.obj == expected_error.obj
+    else:
+        obj_equal = False
     return (
         error.msg == expected_error.msg
         and error.hint == expected_error.hint
         and error.id == expected_error.id
-        and url_pattern_eql(error.obj, expected_error.obj)
+        and obj_equal
     )


### PR DESCRIPTION
This PR contains 
- a bunch of tests for the existing converter behaviour
- some small cleanups of the output text, which also made it easier to write the tests
- a fix for cases where someone subclasses a builtin converter and just changes the regex (which I've come across in my client's code). There is a bit of complexity here as we need to be careful of cases where they might also override the `to_python` method, so we use the [`__mro__`](https://docs.python.org/3.8/library/stdtypes.html#class.__mro__) attribute to traverse the defined methods in the right order.

Thanks again!
