### PR TITLE
Handle default arguments passed via path(kwargs)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 max-line-length = 120
 max-complexity = 18
-ignore = E203, E266, W503, D107
+ignore = E203, E266, W503, D107, C901
 docstring-convention = google
 per-file-ignores =
     __init__.py:F401

--- a/tests/dummy_project/urls/path_kwargs_urls.py
+++ b/tests/dummy_project/urls/path_kwargs_urls.py
@@ -1,0 +1,17 @@
+"""URLs using path(kwargs=)."""
+from django.urls import path
+
+from tests.dummy_project import views
+
+urlpatterns = [
+    # This one is valid, should produce no error
+    path('articles-2020/', views.year_archive, kwargs={'year': 2020}),
+    # This one is missing 'year',
+    path('articles-2021/', views.year_archive),
+    # This one has wrong type:
+    path('articles-2022/', views.year_archive, kwargs={'year': '2022'}),
+    # This one has extra arg which will cause type error:
+    path('articles-2023/', views.year_archive, kwargs={'year': 2023, 'other': 123}),
+    # This one is not typed, can't check
+    path('articles-2024/', views.year_archive_untyped, kwargs={'year': 2024}),
+]

--- a/tests/dummy_project/views.py
+++ b/tests/dummy_project/views.py
@@ -38,6 +38,11 @@ def year_archive(request, year: int):
     ...
 
 
+def year_archive_untyped(request, year):
+    """This is a year archive (with no type hint)"""
+    ...
+
+
 def month_archive(request, year: int, month: int):
     """This is a month archive.
 

--- a/tests/dummy_project/views.py
+++ b/tests/dummy_project/views.py
@@ -39,7 +39,7 @@ def year_archive(request, year: int):
 
 
 def year_archive_untyped(request, year):
-    """This is a year archive (with no type hint)"""
+    """This is a year archive (with no type hint)."""
     ...
 
 


### PR DESCRIPTION
Another issue I found!

An example of this kind of configuration in urlconf is found here - https://docs.djangoproject.com/en/4.1/ref/contrib/sitemaps/#initialization - which is in fact the issue in a project that prompted this.