### PR TITLE
Made error reporting of view reprs consistent with silencer

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -97,7 +97,7 @@ more items:
 
 ```python
 URLCONFCHECKS_SILENCED_VIEWS = {
-    "*.View.as_view.<locals>.view": "W001",  # CBVs
+    "*.View.as_view": "W001",  # CBVs
     "django.views.generic.base.RedirectView": "W001",
     "django.contrib.*": "W003",  # admin etc.
 }


### PR DESCRIPTION
Before, the repr we used for reporting a problem was different from that used for checking against views to silence. This made it hard to know what globs to add.

Also, simplified our _DEFAULT_SILENCED_VIEWS setting, it works with both Django 3.2 and Django 4.0, I also checked against 4.1.
