### PR TITLE
Correctly handle views with Optional arguments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ output will be:
 (urlchecker.E002) For parameter `year`, annotated type int does not match expected `str` from urlconf
 ```
 
-* TODO
+* TODO:
+    - Handle type checking parameterized generics e.g. `typing.List[int]`, `list[str]` etc.
     - Should only warn for each unhandled Converter once.
     - Regex patterns perhaps? (only RoutePattern supported at the moment).
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ It leverages the Django's static check system.
 
     pip install django-urlconfchecks
 
+Python 3.7 or later is required. However, before Python 3.10 some checks
+relating to `Optional` types in view signatures are skipped due to stdlib
+limitations.
+
 ## Usage
 
 You can use this package in different ways:

--- a/django_urlconfchecks/check.py
+++ b/django_urlconfchecks/check.py
@@ -229,6 +229,9 @@ def _type_is_compatible(passed_type, accepted_type):
             # It's difficult to replicate Python 3.10 behaviour. So just let it pass,
             # rather than falsely say it's incompatible.
             return True
+        elif 'parameterized generic' in e.args[0]:
+            # Tricky to handle correctly
+            return True
         else:
             raise  # pragma: no cover
 
@@ -239,6 +242,8 @@ def _instance_is_compatible(instance, accepted_type):
     except TypeError as e:
         # Same as in _type_is_compatible
         if 'Subscripted generics' in e.args[0]:
+            return True
+        elif 'parameterized generic' in e.args[0]:
             return True
         else:
             raise  # pragma: no cover

--- a/django_urlconfchecks/check.py
+++ b/django_urlconfchecks/check.py
@@ -122,9 +122,9 @@ def check_url_args_match(url_pattern: URLPattern) -> t.List[Problem]:
             used_from_sig.append(name)
         elif name in sig.parameters:
             used_from_sig.append(name)
-            expected_type = get_converter_output_type(converter)
-            found_type = sig.parameters[name].annotation
-            if expected_type == Parameter.empty:
+            urlconf_type = get_converter_output_type(converter)
+            sig_type = sig.parameters[name].annotation
+            if urlconf_type == Parameter.empty:
                 # TODO - only output this warning once per converter
                 obj = converter.__class__
                 errors.append(
@@ -135,7 +135,7 @@ def check_url_args_match(url_pattern: URLPattern) -> t.List[Problem]:
                         id=f'urlchecker.W002.{obj.__module__}.{obj.__name__}',
                     )
                 )
-            elif found_type == Parameter.empty:
+            elif sig_type == Parameter.empty:
                 errors.append(
                     # This should be synced with W003 below.
                     checks.Warning(
@@ -144,12 +144,12 @@ def check_url_args_match(url_pattern: URLPattern) -> t.List[Problem]:
                         id='urlchecker.W003',
                     )
                 )
-            elif expected_type != found_type:
+            elif not _type_is_compatible(urlconf_type, sig_type):  # type: ignore
                 errors.append(
                     checks.Error(
                         f'View {callback_repr} for parameter `{name}`,'  # type: ignore[union-attr]
-                        f' annotated type {_name_type(found_type)} does not match'  # type: ignore[union-attr]
-                        f' expected `{_name_type(expected_type)}` from urlconf',  # type: ignore[union-attr]
+                        f' annotated type {_name_type(sig_type)} does not match'  # type: ignore[union-attr]
+                        f' expected `{_name_type(urlconf_type)}` from urlconf',  # type: ignore[union-attr]
                         obj=url_pattern,
                         id='urlchecker.E002',
                     )
@@ -180,7 +180,7 @@ def check_url_args_match(url_pattern: URLPattern) -> t.List[Problem]:
                         id='urlchecker.W003',
                     )
                 )
-            elif not isinstance(default_arg, sig_type):
+            elif not _instance_is_compatible(default_arg, sig_type):
                 errors.append(
                     checks.Error(
                         f'View {callback_repr}: for parameter `{name}`,'
@@ -217,6 +217,31 @@ def check_url_args_match(url_pattern: URLPattern) -> t.List[Problem]:
         )
 
     return errors
+
+
+def _type_is_compatible(passed_type, accepted_type):
+    try:
+        return issubclass(passed_type, accepted_type)
+    except TypeError as e:
+        # For Python < 3.10 we get:
+        #   Subscripted generics cannot be used with class and instance checks
+        if 'Subscripted generics' in e.args[0]:
+            # It's difficult to replicate Python 3.10 behaviour. So just let it pass,
+            # rather than falsely say it's incompatible.
+            return True
+        else:
+            raise  # pragma: no cover
+
+
+def _instance_is_compatible(instance, accepted_type):
+    try:
+        return isinstance(instance, accepted_type)
+    except TypeError as e:
+        # Same as in _type_is_compatible
+        if 'Subscripted generics' in e.args[0]:
+            return True
+        else:
+            raise  # pragma: no cover
 
 
 def _name_type(type_hint):

--- a/tests/dummy_project/urls/child_urls.py
+++ b/tests/dummy_project/urls/child_urls.py
@@ -8,6 +8,5 @@ urlpatterns = [
     path('articles/<str:year>/<str:month>/', views.month_archive),
     path('articles/<str:year>/<int:month>/<slug:slug>/', views.article_detail),
     path('<slug:slug>/', views.bad_view),
-    path('<int:id>/', views.bad_arg),
     path('special-case/<int:param>/', views.special_case),
 ]

--- a/tests/dummy_project/urls/optional_args.py
+++ b/tests/dummy_project/urls/optional_args.py
@@ -1,0 +1,15 @@
+"""URLs with Optional args."""
+from django.urls import path
+
+from tests.dummy_project import views
+
+urlpatterns = [
+    # All these are valid
+    path('good-with-val/<int:val>', views.optional_arg_view),
+    path('good-without-val/', views.optional_arg_view),
+    path('good-with-kwarg1/', views.optional_arg_view, kwargs={'val': None}),
+    path('good-with-kwarg2/', views.optional_arg_view, kwargs={'val': 123}),
+    # These are not
+    path('bad-with-val/<path:val>', views.optional_arg_view),
+    path('bad-with-kwarg1/', views.optional_arg_view, kwargs={'val': "abc"}),
+]

--- a/tests/dummy_project/urls/optional_args.py
+++ b/tests/dummy_project/urls/optional_args.py
@@ -1,4 +1,4 @@
-"""URLs with Optional args."""
+"""Views with Optional args."""
 from django.urls import path
 
 from tests.dummy_project import views

--- a/tests/dummy_project/urls/parameterized_generics.py
+++ b/tests/dummy_project/urls/parameterized_generics.py
@@ -1,0 +1,26 @@
+"""Views with parameterized generics."""
+from django.urls import path
+
+from tests.dummy_project import views
+
+# Currently we aren't able to check to these types (we just allow them to pass
+# and don't crash), but this lists some of the cases we'd need to handle
+
+urlpatterns = [
+    # All these are valid
+    path('good-with-kwarg2/', views.parameterized_generic_view, kwargs={'val': [123]}),
+    # These are not
+    path('bad-with-val/<path:val>', views.parameterized_generic_view),
+    path('bad-with-kwarg1/', views.parameterized_generic_view, kwargs={'val': "abc"}),
+    path('bad-with-kwarg2/', views.parameterized_generic_view, kwargs={'val': ["abc"]}),
+]
+
+if views.parameterized_generic_view_2 is not None:
+    urlpatterns = [
+        # All these are valid
+        path('good-2-with-kwarg2/', views.parameterized_generic_view_2, kwargs={'val': [123]}),
+        # These are not
+        path('bad-2-with-val/<path:val>', views.parameterized_generic_view_2),
+        path('bad-2-with-kwarg1/', views.parameterized_generic_view_2, kwargs={'val': "abc"}),
+        path('bad-2-with-kwarg2/', views.parameterized_generic_view_2, kwargs={'val': ["abc"]}),
+    ]

--- a/tests/dummy_project/views.py
+++ b/tests/dummy_project/views.py
@@ -10,11 +10,6 @@ def bad_view(slug: str):
     ...
 
 
-def bad_arg(request, id: Optional[int] = None):
-    """View with bad argument, using Optional."""
-    ...
-
-
 def special_case(request):
     """This is a special case.
 
@@ -79,3 +74,7 @@ class CBVView(View):
 
     def get(self, request):
         ...
+
+
+def optional_arg_view(request, val: Optional[int] = None):
+    ...

--- a/tests/dummy_project/views.py
+++ b/tests/dummy_project/views.py
@@ -1,6 +1,6 @@
 """views for tests."""
 
-from typing import Optional
+from typing import List, Optional
 
 from django.views import View
 
@@ -78,3 +78,16 @@ class CBVView(View):
 
 def optional_arg_view(request, val: Optional[int] = None):
     ...
+
+
+def parameterized_generic_view(request, val: List[int]):
+    ...
+
+
+try:
+
+    def parameterized_generic_view_2(request, val: list[int]):  # type: ignore
+        ...
+
+except TypeError:
+    parameterized_generic_view_2 = None  # type: ignore

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,4 @@
 """Test module for cli."""
-import sys
-
 import pytest
 from django.conf import settings
 from django.utils.functional import empty
@@ -44,10 +42,9 @@ def test_cli_urlconf_incorrect_one_error():
 def test_cli_urlconf_incorrect_multiple_errors():
     """Test when multiple urlconfs are incorrect."""
     result = runner.invoke(app, ["--urlconf", "tests.dummy_project.urls.child_urls"])
-    optional_int_repr = "typing.Optional[int]" if sys.version_info >= (3, 9) else "typing.Union[int, NoneType]"
 
     assert (
-        "6 errors found:\n"
+        "5 errors found:\n"
         "\t<URLPattern 'articles/<str:year>/<str:month>/'>: (urlchecker.E002) View"
         " tests.dummy_project.views.month_archive for parameter `year`,"
         " annotated type int does not match expected `str` from urlconf\n"
@@ -59,9 +56,6 @@ def test_cli_urlconf_incorrect_multiple_errors():
         " annotated type int does not match expected `str` from urlconf\n"
         "\t<URLPattern '<slug:slug>/'>: (urlchecker.E001) View tests.dummy_project.views.bad_view signature "
         "does not start with `request` parameter, found `slug`.\n"
-        "\t<URLPattern '<int:id>/'>: (urlchecker.E002) View"
-        " tests.dummy_project.views.bad_arg for parameter `id`,"
-        f" annotated type {optional_int_repr} does not match expected `int` from urlconf\n"
         "\t<URLPattern 'special-case/<int:param>/'>: (urlchecker.E003) View tests.dummy_project.views.special_case "
         "signature does not contain `param` parameter\n" == result.output
     )

--- a/tests/test_url_checker.py
+++ b/tests/test_url_checker.py
@@ -1,4 +1,6 @@
 """Tests for `django_urlconfchecks` package."""
+import sys
+
 from django.core import checks
 from django.test.utils import override_settings
 from django.urls import URLPattern
@@ -102,7 +104,7 @@ def test_child_urls_checked():
     with override_settings(ROOT_URLCONF='tests.dummy_project.urls.parent_urls'):
         resolver = get_resolver()
         routes = get_all_routes(resolver)
-        assert len(list(routes)) == 6
+        assert len(list(routes)) == 5
 
 
 def test_admin_urls_ignored():
@@ -213,3 +215,12 @@ def test_path_kwargs():
                 id="urlchecker.W003",
             ),
         )
+
+
+@override_settings(ROOT_URLCONF='tests.dummy_project.urls.optional_args')
+def test_optional_args():
+    errors = check_url_signatures(None)
+    if sys.version_info > (3, 10):
+        assert len(errors) > 0
+    for error in errors:
+        assert error.obj.pattern._route.startswith('bad-')

--- a/tests/test_url_checker.py
+++ b/tests/test_url_checker.py
@@ -220,7 +220,16 @@ def test_path_kwargs():
 @override_settings(ROOT_URLCONF='tests.dummy_project.urls.optional_args')
 def test_optional_args():
     errors = check_url_signatures(None)
-    if sys.version_info > (3, 10):
+    if sys.version_info >= (3, 10):
         assert len(errors) > 0
     for error in errors:
         assert error.obj.pattern._route.startswith('bad-')
+
+
+@override_settings(ROOT_URLCONF='tests.dummy_project.urls.parameterized_generics')
+def test_parameterized_generics():
+    errors = check_url_signatures(None)
+    # Currently errors is empty, but at least we didn't crash
+    # or falsely return errors for things that are fine
+    for error in errors:
+        assert error.obj.pattern._route.startswith('bad-')  # pragma: no cover


### PR DESCRIPTION
If the view sig specifies `int | None`, or `Optional[int]` which means the same, then the URLconf should be allowed to pass either `int` or None.

This involved removing an existing test (`bad_arg` related), which was incorrect, and adding some more specific test cases.

I then found that doing it fully correct was hard on Python < 3.10, so these checks had to be partially skipped for those versions.