### PR TITLE
Handle cases involving `path` and `include`

### DIFF
--- a/tests/dummy_project/urls/includes.py
+++ b/tests/dummy_project/urls/includes.py
@@ -1,0 +1,41 @@
+"""URLs for testing `django.urls.include` support."""
+
+from django.urls import include, path
+
+from tests.dummy_project import views
+
+# When using 'include' which should include parameters collected from before
+
+urlpatterns = [
+    # All these are valid:
+    path(
+        "<int:year>/",
+        include(
+            [
+                # `year` is passed from above
+                path('', views.year_archive, name="good-year-archive"),
+                path('<int:month>/', views.month_archive, name="good-month-archive"),
+                path('<int:month>/<slug:slug>/', views.article_detail, name="good-detail"),
+                path(
+                    'nested/<int:month>/',
+                    include(
+                        [
+                            # `year` and `month` are passed from above
+                            path('', views.month_archive, name="good-month-archive-nested"),
+                        ]
+                    ),
+                ),
+            ]
+        ),
+    ),
+    # These are not
+    path(
+        "bad-include/<slug:slug>/",
+        include(
+            [
+                # year_archive does not take `slug` param
+                path('bad-year/<int:year>', views.year_archive, name="bad-year-archive"),
+            ]
+        ),
+    ),
+]

--- a/tests/test_url_checker.py
+++ b/tests/test_url_checker.py
@@ -91,7 +91,7 @@ def test_all_urls_checked():
     """
     with override_settings(ROOT_URLCONF='tests.dummy_project.urls.correct_urls'):
         resolver = get_resolver()
-        routes = get_all_routes(resolver)
+        routes = get_all_routes(resolver, {})
         assert len(list(routes)) == 3
 
 
@@ -103,7 +103,7 @@ def test_child_urls_checked():
     """
     with override_settings(ROOT_URLCONF='tests.dummy_project.urls.parent_urls'):
         resolver = get_resolver()
-        routes = get_all_routes(resolver)
+        routes = get_all_routes(resolver, {})
         assert len(list(routes)) == 5
 
 
@@ -233,3 +233,13 @@ def test_parameterized_generics():
     # or falsely return errors for things that are fine
     for error in errors:
         assert error.obj.pattern._route.startswith('bad-')  # pragma: no cover
+
+
+@override_settings(ROOT_URLCONF='tests.dummy_project.urls.includes')
+def test_includes():
+    # Positive and negative tests that parameters collected by `path` should be
+    # taken into account by routes that are `include`d
+    errors = check_url_signatures(None)
+    assert len(errors) > 0
+    for error in errors:
+        assert error.obj.pattern._route.startswith('bad-')


### PR DESCRIPTION
Where we have:

```python
urlpatterns = [
    path(
        "<str:some_param>/",
        include(
            [path('', view_func)]
        )
]
```

Then view_func will be passed `some_param`. This PR adds support for this.